### PR TITLE
Preserve wrapee function signature in func() decorator

### DIFF
--- a/region_profiler/global_instance.py
+++ b/region_profiler/global_instance.py
@@ -6,6 +6,7 @@ from region_profiler.debug_listener import DebugListener
 from region_profiler.profiler import RegionProfiler
 from region_profiler.reporters import ConsoleReporter
 from region_profiler.utils import NullContext
+import functools
 
 _profiler = None
 """Global :py:class:`RegionProfiler` instance.
@@ -109,6 +110,7 @@ def func(name=None, asglobal=False):
 
         name += '()'
 
+        @functools.wraps(fn)
         def wrapped(*args, **kwargs):
             with region(name, asglobal=asglobal):
                 return fn(*args, **kwargs)


### PR DESCRIPTION
without functools.wrap decorator

the function to be profiled has \__name__ "wrapped"
```
import region_profiler as rp

@rp.func()
def my_func():
    pass

print(f'"{my_func.__name__}()"') # "my_func()"
```